### PR TITLE
feat: dynamically generate drawer items

### DIFF
--- a/build/drawer-items-plugin.js
+++ b/build/drawer-items-plugin.js
@@ -1,0 +1,59 @@
+const fs = require('fs')
+const path = require('path')
+const glob = require('glob')
+const VirtualModulesPlugin = require('webpack-virtual-modules')
+const frontmatter = require('front-matter')
+const { kebabCase } = require('lodash')
+
+const getItems = (files) => {
+  return files.reduce((items, filePath) => {
+    const { attributes } = frontmatter(fs.readFileSync(filePath, 'utf-8'))
+
+    if (!attributes.nav) return items
+
+    const dir = path.dirname(filePath.replace('./src/pages/en', ''))
+    const file = kebabCase(path.basename(filePath, path.extname(filePath)))
+
+    items.push({
+      title: attributes.title,
+      nav: dir.slice(1),
+      href: `${dir}/${file}`,
+    })
+
+    return items
+  }, [])
+}
+
+class Plugin {
+  apply (compiler) {
+    let shouldWrite = false
+    const files = glob.sync('./src/pages/en/**/*.md')
+    const content = files => `module.exports = ${JSON.stringify(getItems(files))};`
+
+    const virtualModules = new VirtualModulesPlugin({
+      'node_modules/DrawerItems.js': content(files),
+    })
+
+    virtualModules.apply(compiler)
+
+    compiler.hooks.compilation.tap('DrawerItemsPlugin', () => {
+      if (!shouldWrite) return
+
+      virtualModules.writeModule('node_modules/DrawerItems.js', content(files))
+
+      shouldWrite = false
+    })
+
+    compiler.hooks.watchRun.tap('DrawerItemsPlugin', (comp) => {
+      const changedTimes = comp.watchFileSystem.watcher.mtimes
+      const changedFiles = Object.keys(changedTimes)
+        .filter(file => files.find(f => f.indexOf(path.basename(file)) >= 0))
+
+      if (changedFiles.length) {
+        shouldWrite = true
+      }
+    })
+  }
+}
+
+module.exports = Plugin

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "vuetify-loader": "^1.3.0",
     "vuex-pathify": "^1.4.1",
     "vuex-router-sync": "^5.0.0",
-    "webfontloader": "^1.6.28"
+    "webfontloader": "^1.6.28",
+    "webpack-virtual-modules": "^0.2.2"
   }
 }

--- a/src/layouts/default/Drawer.vue
+++ b/src/layouts/default/Drawer.vue
@@ -1,15 +1,52 @@
 <template>
   <v-navigation-drawer app>
     <v-list>
-      <v-list-item>
-        <v-list-item-title>Drawer Item</v-list-item-title>
-      </v-list-item>
+      <v-list-group
+        v-for="item in items"
+        :key="item.title"
+        :prepend-icon="item.icon"
+        no-action
+      >
+        <template v-slot:activator>
+          <v-list-item-content>
+            <v-list-item-title v-text="item.title" />
+          </v-list-item-content>
+        </template>
+
+        <v-list-item
+          v-for="subItem in item.items"
+          :key="subItem.title"
+          :href="subItem.href"
+        >
+          <v-list-item-content>
+            <v-list-item-title v-text="subItem.title" />
+          </v-list-item-content>
+        </v-list-item>
+      </v-list-group>
     </v-list>
   </v-navigation-drawer>
 </template>
 
 <script>
+  import DrawerItems from 'DrawerItems'
+
   export default {
     name: 'DefaultDrawer',
+    computed: {
+      items () {
+        return [
+          {
+            title: 'Getting started',
+            icon: 'mdi-home',
+            items: DrawerItems.filter(item => item.nav === 'getting-started'),
+          },
+          {
+            title: 'Components',
+            icon: 'mdi-view-dashboard',
+            items: DrawerItems.filter(item => item.nav.startsWith('components')),
+          },
+        ]
+      },
+    },
   }
 </script>

--- a/src/pages/en/components/VAlert.md
+++ b/src/pages/en/components/VAlert.md
@@ -1,9 +1,9 @@
 ---
-layout: documentation
 title: V-Alert
+layout: documentation
 description: The v-alert component is used to convey information to the user. Designed to stand out, the alerts come in four contextual styles.
 keywords: v-alert, alerts, vue alert component, vuetify alert component
-nav: components/alerts
+nav: true
 ---
 
 # V-Alert

--- a/src/pages/en/getting-started/QuickStart.md
+++ b/src/pages/en/getting-started/QuickStart.md
@@ -2,6 +2,7 @@
 title: Quick Start
 description: Get started with Vue and Vuetify in no time. Support for Vue CLI, Webpack, Nuxt and more.
 keywords: quick start, vuetify templates, installing vuetify, install vuetify
+nav: true
 ---
 
 # Quick start

--- a/src/plugins/webfontloader.js
+++ b/src/plugins/webfontloader.js
@@ -11,4 +11,12 @@ WebFontLoader.load({
   google: {
     families: ['Roboto:100,300,400,500,700,900&display=swap'],
   },
+  custom: {
+    families: [
+      'Material Design Icons',
+    ],
+    urls: [
+      'https://cdn.jsdelivr.net/npm/@mdi/font@4.x/css/materialdesignicons.min.css',
+    ],
+  },
 })

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,6 @@
 
 // Utilities
+const path = require('path')
 const Mode = require('frontmatter-markdown-loader/mode')
 const { md } = require('./build/markdown-it')
 
@@ -8,6 +9,10 @@ module.exports = {
     disableHostCheck: true,
   },
   chainWebpack: config => {
+    config
+      .plugin('drawer-items-plugin')
+      .use(path.resolve('./build/drawer-items-plugin.js'))
+
     config.module
       .rule('markdown')
       .test(/\.md$/)

--- a/yarn.lock
+++ b/yarn.lock
@@ -11170,6 +11170,13 @@ webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
+webpack-virtual-modules@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.2.2.tgz#20863dc3cb6bb2104729fff951fbe14b18bd0299"
+  integrity sha512-kDUmfm3BZrei0y+1NTHJInejzxfhtU8eDj2M7OKb2IWrPFAeO1SOH2KuQ68MSZu9IGEHcxbkKKR1v18FrUSOmA==
+  dependencies:
+    debug "^3.0.0"
+
 webpack@^4.0.0:
   version "4.43.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.43.0.tgz#c48547b11d563224c561dad1172c8aa0b8a678e6"


### PR DESCRIPTION
generate drawer items on build. markdown files can indicate if they should be added to drawer by setting `nav: true` attribute. url is generated from file path so that it matches how router looks for files.