### PR TITLE
fix: do not render vuetify ads if there is no data

### DIFF
--- a/src/components/ad/Vuetify.vue
+++ b/src/components/ad/Vuetify.vue
@@ -1,6 +1,7 @@
 <template>
   <app-ad width="100%">
     <v-list
+      v-if="hasAvailableAds"
       class="py-0"
       color="transparent"
     >
@@ -44,12 +45,17 @@
 
     computed: {
       ads: get('ads/available'),
+      hasAvailableAds () {
+        return !!this.ads.length
+      },
       activeTemplate () {
         const length = this.ads.length
 
         return this.ads[Math.floor(Math.random() * length)]
       },
       adAttrs () {
+        if (!this.activeTemplate) return null
+
         const [url, query] = this.activeTemplate.metadata.url.split('?')
 
         if (url.charAt(0) === '/') {


### PR DESCRIPTION
We're still creating the cosmic bucket without checking if we actually have env variables. We could probably also skip doing it for anything other than production.