### PR TITLE
refactor: make eventual transition to vue 3 easier

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import App from './App.vue'
-import './plugins'
+import { registerPlugins } from './plugins'
 import { createVuetify } from './plugins/vuetify'
 import { createStore } from '@/store/index'
 import { createRouter } from '@/router/index'
@@ -14,6 +14,8 @@ const router = createRouter()
 const vuetify = createVuetify()
 
 sync(store, router)
+
+registerPlugins(Vue)
 
 new Vue({
   router,

--- a/src/plugins/app.js
+++ b/src/plugins/app.js
@@ -5,17 +5,16 @@
  * in the `./src/components/` folder.
  */
 
-// Imports
-import Vue from 'vue'
+export function registerComponents (app) {
+  // Get all .vue files within `src/components/app`
+  const requireComponent = require.context('@/components', true, /\.vue$/)
 
-// Get all .vue files within `src/components/app`
-const requireComponent = require.context('@/components', true, /\.vue$/)
+  for (const file of requireComponent.keys()) {
+    const componentConfig = requireComponent(file)
 
-for (const file of requireComponent.keys()) {
-  const componentConfig = requireComponent(file)
-
-  Vue.component(
-    componentConfig.default.name,
-    componentConfig.default || componentConfig,
-  )
+    app.component(
+      componentConfig.default.name,
+      componentConfig.default || componentConfig,
+    )
+  }
 }

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -4,6 +4,14 @@
  * Automatically included in `./src/main.js`
  */
 
-import './app'
-import './webfontloader'
-import './vue-meta'
+import { registerComponents } from './app'
+import { loadFonts } from './webfontloader'
+import { useMeta } from './vue-meta'
+import { useVuetify } from './vuetify'
+
+export function registerPlugins (app) {
+  registerComponents(app)
+  loadFonts(app)
+  useMeta(app)
+  useVuetify(app)
+}

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -4,8 +4,8 @@
  * Automatically included in `./src/main.js`
  */
 
-import { registerComponents } from './app'
 import { loadFonts } from './webfontloader'
+import { registerComponents } from './app'
 import { useMeta } from './vue-meta'
 import { useVuetify } from './vuetify'
 

--- a/src/plugins/vue-cookies.js
+++ b/src/plugins/vue-cookies.js
@@ -1,4 +1,5 @@
-import Vue from 'vue'
 import Cookies from 'vue-cookies'
 
-Vue.use(Cookies)
+export function useCookies (app) {
+  app.use(Cookies)
+}

--- a/src/plugins/vue-meta.js
+++ b/src/plugins/vue-meta.js
@@ -1,5 +1,6 @@
 // Imports
-import Vue from 'vue'
 import Meta from 'vue-meta'
 
-Vue.use(Meta)
+export function useMeta (app) {
+  app.use(Meta)
+}

--- a/src/plugins/vuetify.js
+++ b/src/plugins/vuetify.js
@@ -5,7 +5,6 @@
  */
 
 // Imports
-import Vue from 'vue'
 import Vuetify from 'vuetify/lib/framework'
 
 import {
@@ -17,8 +16,6 @@ import {
   mdiViewDashboard,
 } from '@mdi/js'
 
-Vue.use(Vuetify)
-
 const icons = {
   iconfont: 'mdiSvg',
   values: {
@@ -29,6 +26,10 @@ const icons = {
     mdiTranslate,
     mdiViewDashboard,
   },
+}
+
+export function useVuetify (app) {
+  app.use(Vuetify)
 }
 
 export function createVuetify () {

--- a/src/plugins/webfontloader.js
+++ b/src/plugins/webfontloader.js
@@ -7,8 +7,10 @@
  // Imports
 import WebFontLoader from 'webfontloader'
 
-WebFontLoader.load({
-  google: {
-    families: ['Roboto:100,300,400,500,700,900&display=swap'],
-  },
-})
+export function loadFonts () {
+  WebFontLoader.load({
+    google: {
+      families: ['Roboto:100,300,400,500,700,900&display=swap'],
+    },
+  })
+}


### PR DESCRIPTION
In vue 3 `use/component` etc live on the app instance, not `Vue`