### PR TITLE
refactor(Toc): changed way we generate toc headings

### DIFF
--- a/build/toc-loader.js
+++ b/build/toc-loader.js
@@ -1,0 +1,41 @@
+const { md } = require('./markdown-it')
+
+function getPageHeadings (page) {
+  const headings = []
+  const tokens = md.parse(page, {})
+  const length = tokens.length
+
+  for (let i = 0; i < length; i++) {
+    const token = tokens[i]
+
+    if (token.type !== 'heading_open') continue
+
+    // heading level by hash length '###' === h3
+    const level = token.markup.length
+
+    if (level <= 1) continue
+
+    const next = tokens[i + 1]
+    const link = next.children[0]
+    const text = next.content
+    const [, href] = link.attrs.find(([attr]) => attr === 'href')
+
+    headings.push({
+      text,
+      href,
+      level,
+    })
+  }
+
+  return headings
+}
+
+function loader (source) {
+  // Replace body string with toc headings
+  return source.replace(/body:\s"(.*)",/g, (_, markdown) => {
+    const headings = getPageHeadings(markdown.replace(/\\n/g, '\n'))
+    return `toc: ${JSON.stringify(headings)},`
+  })
+}
+
+module.exports = loader

--- a/src/layouts/documentation/Index.vue
+++ b/src/layouts/documentation/Index.vue
@@ -41,22 +41,12 @@
       ]),
       ...sync('i18n', [
         'pages',
-        'tocs',
       ]),
       locale: get('route/params@locale'),
     },
 
     methods: {
-      async getHeadings () {
-        const { default: headings } = await import(
-          /* webpackChunkName: "headings" */
-          `@docs/${this.locale}/headings`
-        )
-
-        this.tocs = headings
-      },
       async init () {
-        this.getHeadings()
         this.getModified()
         this.getPages()
       },

--- a/src/layouts/documentation/Toc.vue
+++ b/src/layouts/documentation/Toc.vue
@@ -41,10 +41,7 @@
     computed: {
       category: get('route/params@category'),
       page: get('route/params@page'),
-      tocs: get('i18n/tocs'),
-      toc () {
-        return this.tocs && this.tocs[this.category] && this.tocs[this.category][this.page]
-      },
+      toc: get('page/toc'),
     },
   }
 </script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -18,6 +18,7 @@ export function createRouter (store, i18n) {
     },
     routes: [
       {
+        name: 'Home',
         path: '/:locale',
         component: () => import('@/layouts/locale/Index'),
         children: [

--- a/src/store/modules/i18n.js
+++ b/src/store/modules/i18n.js
@@ -7,7 +7,6 @@ import { make } from 'vuex-pathify'
 const state = {
   frontmatter: {},
   pages: {},
-  tocs: {},
 }
 
 const mutations = make.mutations(state)

--- a/src/store/modules/index.js
+++ b/src/store/modules/index.js
@@ -1,3 +1,4 @@
 export { default as ads } from './ads'
 export { default as app } from './app'
 export { default as i18n } from './i18n'
+export { default as page } from './page'

--- a/src/store/modules/page.js
+++ b/src/store/modules/page.js
@@ -1,0 +1,25 @@
+// Pathify
+import { make } from 'vuex-pathify'
+
+// Data
+const state = {
+  toc: [],
+}
+
+const mutations = make.mutations(state)
+
+const actions = {
+  init: ({ commit }, { toc }) => {
+    commit('toc', toc)
+  },
+}
+
+const getters = {}
+
+export default {
+  namespaced: true,
+  state,
+  mutations,
+  actions,
+  getters,
+}

--- a/src/views/Page.vue
+++ b/src/views/Page.vue
@@ -12,7 +12,7 @@
 <script>
   // Utilities
   import { genMetaData } from '@/util/metadata'
-  import { sync } from 'vuex-pathify'
+  import { sync, call } from 'vuex-pathify'
 
   // This should only be extended by other pages
   export default {
@@ -57,12 +57,15 @@
     },
 
     methods: {
+      init: call('page/init'),
       async load () { return {} },
       async update () {
         const fm = await this.load(this.$route)
 
         this.component = fm.default.vue.component
         this.frontmatter = fm.default.attributes
+
+        this.init({ toc: fm.toc })
       },
     },
   }

--- a/vue.config.js
+++ b/vue.config.js
@@ -47,11 +47,14 @@ module.exports = {
     config.module
       .rule('markdown')
       .test(/\.md$/)
+      .use('toc-loader')
+        .loader(path.resolve('./build/toc-loader.js'))
+        .end()
       .use('frontmatter-markdown-loader')
         .loader('frontmatter-markdown-loader')
         .tap(() => ({
           markdown: body => md.render(body),
-          mode: [Mode.VUE_COMPONENT],
+          mode: [Mode.VUE_COMPONENT, Mode.BODY],
           vue: { root: 'markdown-body' },
         }))
   },


### PR DESCRIPTION
instead of generating them by parsing real markdown files, we add them
to frontmatter output when actually requesting a markdown file.

this way we get headings for virtual markdown files as well, like
the api pages.

this is of course predicated on the assumption that toc headings are only used when viewing a particular page.