### PR TITLE
fix(Page): increase max-width of page content

### DIFF
--- a/src/views/Page.vue
+++ b/src/views/Page.vue
@@ -2,7 +2,7 @@
   <v-container tag="section">
     <v-responsive
       class="mx-auto overflow-visible px-6"
-      max-width="768"
+      max-width="868"
     >
       <component :is="component" />
     </v-responsive>


### PR DESCRIPTION
720px width is not enough when viewing docs full-screen. It feels very narrow. In my opinion it could probably be increased more than 100px. Thoughts?